### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ My personal list of important content related to Mobile Robotics and AI. Feel fr
 * [JAI: Robótica e Simulação com o V-REP](https://www.sites.google.com/site/vrepjai/home) | CSBC - Julho 2015
 * [Digital Image Processing](https://sisu.ut.ee/imageprocessing/avaleht) | University of Tartu - Prof. Dr. Gholamreza Anbarjafari
 * [Tutorial on Visual Odometry](https://sites.google.com/site/scarabotix/tutorial-on-visual-odometry) | University of Zurich - Prof. Davide Scaramuzza
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [Visual SLAM Tutorial](http://www.cs.cmu.edu/~kaess/vslam_cvpr14/) | Frank Dellaert and Michael Kaess
 * [Visual Odometry from scratch - A tutorial for beginners](https://avisingh599.github.io/vision/visual-odometry-full/) | Avi Singh's blog
 * [Aerial Robot Courses](http://www.kostasalexis.com/courses.html) | University of Nevada - Dr. Kostas Alexis

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ My personal list of important content related to Mobile Robotics and AI. Feel fr
 * [JAI: Robótica e Simulação com o V-REP](https://www.sites.google.com/site/vrepjai/home) | CSBC - Julho 2015
 * [Digital Image Processing](https://sisu.ut.ee/imageprocessing/avaleht) | University of Tartu - Prof. Dr. Gholamreza Anbarjafari
 * [Tutorial on Visual Odometry](https://sites.google.com/site/scarabotix/tutorial-on-visual-odometry) | University of Zurich - Prof. Davide Scaramuzza
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/mobile-robotics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [Visual SLAM Tutorial](http://www.cs.cmu.edu/~kaess/vslam_cvpr14/) | Frank Dellaert and Michael Kaess
 * [Visual Odometry from scratch - A tutorial for beginners](https://avisingh599.github.io/vision/visual-odometry-full/) | Avi Singh's blog
 * [Aerial Robot Courses](http://www.kostasalexis.com/courses.html) | University of Nevada - Dr. Kostas Alexis


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/programming-languages/mobile-robotics) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/mobile-robotics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.